### PR TITLE
Feat/tektelic old config

### DIFF
--- a/packaging/tektelic/files/dps-client-daemon.sh
+++ b/packaging/tektelic/files/dps-client-daemon.sh
@@ -7,6 +7,7 @@ DEFAULT_CONFIG_FILE="/etc/opt/mydevices/default.toml"
 CONFIG_DIR="/etc/chirpstack-gateway-bridge"
 CONFIG_FILE="$CONFIG_DIR/chirpstack-gateway-bridge.toml"
 TEMP_CONFIG_FILE="$CONFIG_FILE.tmp"
+OLD_CONFIG_FILE="/var/config/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml"
 
 obtain_gwid() {
     for ((i=0; i<60; i++)); do
@@ -28,10 +29,20 @@ do
     mkdir -p $CONFIG_DIR
     DPS_CLIENT_ARGS="-i $DEFAULT_CONFIG_FILE -r $DEVEUI -c $CERT_DIR/$DEVEUI.cert.pem -k $CERT_DIR/$DEVEUI.key.pem -o $TEMP_CONFIG_FILE"
     /opt/mydevices/dps-client $DPS_CLIENT_ARGS
+    RESTART_CHIRPSTACK=false
+    if test -f "$OLD_CONFIG_FILE"; then
+        if ! cmp -s "$TEMP_CONFIG_FILE" "$OLD_CONFIG_FILE" ; then
+            cp "$TEMP_CONFIG_FILE" "$OLD_CONFIG_FILE"
+            RESTART_CHIRPSTACK=true
+        fi
+    fi
     if cmp -s "$TEMP_CONFIG_FILE" "$CONFIG_FILE" ; then
         rm "$TEMP_CONFIG_FILE"
     else
         mv "$TEMP_CONFIG_FILE" "$CONFIG_FILE"
+        RESTART_CHIRPSTACK=true
+    fi
+    if [ "$RESTART_CHIRPSTACK" = true ]; then
         /etc/init.d/chirpstack-gateway-bridge restart
     fi
 	sleep 7d

--- a/packaging/tektelic/files/dps-client-daemon.sh
+++ b/packaging/tektelic/files/dps-client-daemon.sh
@@ -45,5 +45,5 @@ do
     if [ "$RESTART_CHIRPSTACK" = true ]; then
         /etc/init.d/chirpstack-gateway-bridge restart
     fi
-	sleep 7d
+    sleep 7d
 done


### PR DESCRIPTION
Replace the config file at the old location in addition to the new location so the new metadata changes can be used by older versions. This makes it possible to verify the new dps-client has installed before attempting to update chirpstack which is needed due to the changed config file location used by the Tektelic chirpstack-gateway-bridge.