### PR TITLE
Connection timeout increase and metadata updates

### DIFF
--- a/packaging/gemtek/files/default.toml
+++ b/packaging/gemtek/files/default.toml
@@ -43,5 +43,6 @@
       hardware_version = "/mnt/data/myd/myd/metadata.sh hardware_version"
       mac = "/mnt/data/myd/myd/metadata.sh mac"
       manufacturer = "/mnt/data/myd/myd/metadata.sh manufacturer"
+      marshaler = "/mnt/data/myd/myd/metadata.sh marshaler"
       model = "/mnt/data/myd/myd/metadata.sh model"
       serial = "/mnt/data/myd/myd/metadata.sh serial"

--- a/packaging/gemtek/files/default.toml
+++ b/packaging/gemtek/files/default.toml
@@ -19,6 +19,7 @@
   marshaler = "json"
 
   [integration.mqtt]
+    max_token_wait = "60s"
 
     [integration.mqtt.auth]
       type = "azure_iot_hub"

--- a/packaging/gemtek/files/metadata.sh
+++ b/packaging/gemtek/files/metadata.sh
@@ -1,9 +1,9 @@
 #!/bin/sh
 
+CONFIG_FILE="/mnt/data/app/azureiot/chirpstack-gateway-bridge.toml"
 
 case "$1" in
     "cert_expiration")
-        CONFIG_FILE="/mnt/data/app/azureiot/chirpstack-gateway-bridge.toml"
         CERT_PATH=$(grep tls_cert $CONFIG_FILE | cut -d \" -f2)
         openssl x509 -noout -in $CERT_PATH -enddate  | cut -d= -f2
         ;;
@@ -41,6 +41,9 @@ case "$1" in
     "firmware_version")
         uci get -c /etc/config profile.system.fw_version
         ;;
+    "marshaler")
+        grep marshaler $CONFIG_FILE | grep -v $(basename "$0") | cut -d \" -f2
+        ;;        
     *)
         exit 1
     ;;

--- a/packaging/multitech/files/default.toml
+++ b/packaging/multitech/files/default.toml
@@ -46,6 +46,7 @@
       imsi = "/opt/mydevices/metadata.sh imsi"
       mac = "/usr/sbin/mts-io-sysfs show mac-eth"
       manufacturer = "/usr/sbin/mts-io-sysfs show vendor-id"
+      marshaler = "/opt/mydevices/metadata.sh marshaler"
       model = "/usr/sbin/mts-io-sysfs show product-id"
       ppp_ip = "/opt/mydevices/metadata.sh ppp_ip"
       rssi = "/opt/mydevices/metadata.sh rssi"

--- a/packaging/multitech/files/default.toml
+++ b/packaging/multitech/files/default.toml
@@ -19,7 +19,8 @@
   marshaler = "json"
 
   [integration.mqtt]
-
+    max_token_wait = "60s"
+    
     [integration.mqtt.auth]
       type = "azure_iot_hub"
 

--- a/packaging/multitech/files/default.toml
+++ b/packaging/multitech/files/default.toml
@@ -48,6 +48,7 @@
       manufacturer = "/usr/sbin/mts-io-sysfs show vendor-id"
       model = "/usr/sbin/mts-io-sysfs show product-id"
       ppp_ip = "/opt/mydevices/metadata.sh ppp_ip"
+      rssi = "/opt/mydevices/metadata.sh rssi"
       serial = "/usr/sbin/mts-io-sysfs show device-id"
       today_rx = "/opt/mydevices/metadata.sh today_rx"
       today_tx = "/opt/mydevices/metadata.sh today_tx"

--- a/packaging/multitech/files/metadata.sh
+++ b/packaging/multitech/files/metadata.sh
@@ -1,5 +1,14 @@
 #!/bin/sh
 
+function get_json_value () {
+    endpoint=$1
+    key=$2
+    if [ -x "$(command -v python3)" ]; then
+        echo $(curl -s $endpoint | python3 -c "import sys, json; print(json.load(sys.stdin)['result']['$key'])")
+    else
+        echo $(curl -s $endpoint | python -c "import sys, json; print json.load(sys.stdin)['result']['$key']")
+    fi
+}
 
 case "$1" in
     "cert_expiration")
@@ -17,26 +26,29 @@ case "$1" in
         mts-io-sysfs show lora/eui | tr -d : | tr '[:upper:]' '[:lower:]'
         ;;    
     "eth_ip")
-        curl -s localhost/api/stats/eth0 | python -c "import sys, json; print json.load(sys.stdin)['result']['ip']"
+        get_json_value "localhost/api/stats/eth0" "ip"
         ;;
     "ppp_ip")
-        curl -s localhost/api/stats/ppp | python -c "import sys, json; print json.load(sys.stdin)['result']['localIp']"
+        get_json_value "localhost/api/stats/ppp" "localIp"
         ;;
     "apn")
-        curl -s localhost/api/ppp/modem | python -c "import sys, json; print json.load(sys.stdin)['result']['apnString']"
+        get_json_value "localhost/api/ppp/modem" "apnString"
         ;;
     "imsi")
-        curl -s localhost/api/system | python -c "import sys, json; print json.load(sys.stdin)['result']['imsi']"
+        get_json_value "localhost/api/system" "imsi"
         ;;
     "today_tx")
-        curl -s localhost/api/stats/pppTotal | python -c "import sys, json; print json.load(sys.stdin)['result']['todayTx']"
+        get_json_value "localhost/api/stats/pppTotal" "todayTx"
         ;;
     "today_rx")
-        curl -s localhost/api/stats/pppTotal | python -c "import sys, json; print json.load(sys.stdin)['result']['todayRx']"
+        get_json_value "localhost/api/stats/pppTotal" "todayRx"
         ;;
     "firmware_version")
-        curl -s localhost/api/system | python -c "import sys, json; print json.load(sys.stdin)['result']['firmware']"
+        get_json_value "localhost/api/system" "firmware"
         ;;
+    "rssi")
+        get_json_value "localhost/api/stats/ppp" "rssiDbm"
+        ;;          
     *)
         exit 1
     ;;

--- a/packaging/multitech/files/metadata.sh
+++ b/packaging/multitech/files/metadata.sh
@@ -1,5 +1,7 @@
 #!/bin/sh
 
+CONFIG_FILE="/var/config/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml"
+
 function get_json_value () {
     endpoint=$1
     key=$2
@@ -12,7 +14,6 @@ function get_json_value () {
 
 case "$1" in
     "cert_expiration")
-        CONFIG_FILE="/var/config/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml"
         CERT_PATH=$(grep tls_cert $CONFIG_FILE | cut -d \" -f2)
         openssl x509 -noout -in $CERT_PATH -enddate  | cut -d= -f2
         ;;
@@ -48,7 +49,10 @@ case "$1" in
         ;;
     "rssi")
         get_json_value "localhost/api/stats/ppp" "rssiDbm"
-        ;;          
+        ;;
+    "marshaler")
+        grep marshaler $CONFIG_FILE | grep -v $(basename "$0") | cut -d \" -f2
+        ;;
     *)
         exit 1
     ;;

--- a/packaging/tektelic/files/default.toml
+++ b/packaging/tektelic/files/default.toml
@@ -51,6 +51,7 @@
       manufacturer = "/opt/mydevices/metadata.sh manufacturer"
       model = "/opt/mydevices/metadata.sh model"
       power_source = "/opt/mydevices/metadata.sh power_source"
+      rssi = "/opt/mydevices/metadata.sh rssi"
       serial = "/opt/mydevices/metadata.sh serial"
       voltage = "/opt/mydevices/metadata.sh voltage"
       wwan_ip = "/opt/mydevices/metadata.sh wwan_ip"

--- a/packaging/tektelic/files/default.toml
+++ b/packaging/tektelic/files/default.toml
@@ -19,6 +19,7 @@
   marshaler = "json"
 
   [integration.mqtt]
+    max_token_wait = "60s"
 
     [integration.mqtt.auth]
       type = "azure_iot_hub"

--- a/packaging/tektelic/files/default.toml
+++ b/packaging/tektelic/files/default.toml
@@ -49,6 +49,7 @@
       imsi = "/opt/mydevices/metadata.sh imsi"
       mac = "/opt/mydevices/metadata.sh mac"
       manufacturer = "/opt/mydevices/metadata.sh manufacturer"
+      marshaler = "/opt/mydevices/metadata.sh marshaler"
       model = "/opt/mydevices/metadata.sh model"
       power_source = "/opt/mydevices/metadata.sh power_source"
       rssi = "/opt/mydevices/metadata.sh rssi"

--- a/packaging/tektelic/files/metadata.sh
+++ b/packaging/tektelic/files/metadata.sh
@@ -1,10 +1,10 @@
 #!/bin/sh
 
+CONFIG_FILE="/etc/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml"
 COMMISSION_DB="/tmp/commissioning.db"
 
 case "$1" in
     "cert_expiration")
-        CONFIG_FILE="/etc/chirpstack-gateway-bridge/chirpstack-gateway-bridge.toml"
         CERT_PATH=$(grep tls_cert $CONFIG_FILE | cut -d \" -f2)
         openssl x509 -noout -in $CERT_PATH -enddate  | cut -d= -f2
         ;;
@@ -73,6 +73,9 @@ case "$1" in
     "rssi")
         snmpget -v2c -Oqv -m all -c set localhost wmSignalStrength.0 2> /dev/null
         ;;        
+    "marshaler")
+        grep marshaler $CONFIG_FILE | grep -v $(basename "$0") | cut -d \" -f2
+        ;;       
     *)
         exit 1
     ;;

--- a/packaging/tektelic/files/metadata.sh
+++ b/packaging/tektelic/files/metadata.sh
@@ -70,6 +70,9 @@ case "$1" in
     "charge_complete")
         snmpget -v2c -Oqv -m all -c set localhost pwrBatteryChargeComplete.0 2> /dev/null
         ;;
+    "rssi")
+        snmpget -v2c -Oqv -m all -c set localhost wmSignalStrength.0 2> /dev/null
+        ;;        
     *)
         exit 1
     ;;


### PR DESCRIPTION
<!--
Title:
<jira card>: <brief description>

Example:
SS-4242: Users were unable to login.

Without card:
<type of fix>: <short summary>

Example:
fix(users): issue sign up request to Keycloak on user sign up
-->

<!--
Short summary of what is being done.
Complete sentence, written as though it was an order.
Follow by empty line.

Example:
fix(users): issue sign up request to Keycloak on user sign up
-->
### Summary
Increase the connection timeout and add RSSI and marshaler metadata

<!--
Informative description of what is being solved and why this approach was used.

Provide any relevant information: PR dependencies, unit tests, etc.

Example:
Users were unable to sign up due to API not issuing a request to the Keycloak server. This created
an entry in DB but not in Keycloak server.
-->
### Description
The chirpstack-gateway-bridge was sometimes getting into a state where it would get in a loop where it would continually reconnect. It seems like this might be caused by the discrepancy between the chirpstack connection timeout and the underlying Paho connection timeout. To try and prevent that a longer timeout has been added to the chirpstack config toml file. In addition this adds RSSI and marshaler metadata and a fix for missing metadata on newer Multitech firmware due to an updated python version.

<!--
Additional Links such as jira cards which can be auto linked by Jira bot with format of: <project>-<number>.

Example:
[SS-4242]
-->
### Additional Links
[SS-9189](https://mydevices.atlassian.net/browse/SS-9189)
