### PR TITLE
Add Gemtek firmware update command

### DIFF
--- a/packaging/gemtek/files/command-ctrl.sh
+++ b/packaging/gemtek/files/command-ctrl.sh
@@ -115,10 +115,19 @@ update_certs() {
     exit 0
 }
 
+update_firmware() {
+    sh -c 'sleep 10; /mnt/data/myd/myd/myd_ota stable' >&- 2>&- &
+
+    exit 0    
+}
+
 update() {
     if [ "$UPDATE_TYPE" == "cert" ]; then
         update_certs
     fi
+    if [ "$UPDATE_TYPE" == "firmware" ]; then
+        update_firmware
+    fi    
     if [ -z "$UPDATE_URL" ]; then
         echo "\$UPDATE_URL is empty" >> $LOG_FILE 2>&1
         exit 1


### PR DESCRIPTION
<!--
Title:
<jira card>: <brief description>

Example:
SS-4242: Users were unable to login.

Without card:
<type of fix>: <short summary>

Example:
fix(users): issue sign up request to Keycloak on user sign up
-->

<!--
Short summary of what is being done.
Complete sentence, written as though it was an order.
Follow by empty line.

Example:
fix(users): issue sign up request to Keycloak on user sign up
-->
### Summary
Add a new firmware update type to the update command.

<!--
Informative description of what is being solved and why this approach was used.

Provide any relevant information: PR dependencies, unit tests, etc.

Example:
Users were unable to sign up due to API not issuing a request to the Keycloak server. This created
an entry in DB but not in Keycloak server.
-->
### Description
Gemtek added a new myd_ota executable which installs Gemtek's firmware. This can now be launched remotely via the update command.

<!--
Additional Links such as jira cards which can be auto linked by Jira bot with format of: <project>-<number>.


Example:
[SS-4242]
-->
### Additional Links
